### PR TITLE
Dealing with ZVOL, part 1

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -405,7 +405,7 @@ typedef enum {
 } zfs_crypto_zckey_t;
 
 extern int zfs_crypto_zckey(libzfs_handle_t *, zfs_crypto_zckey_t,
-                            nvlist_t *, struct zfs_cmd *);
+                            nvlist_t *, struct zfs_cmd *, zfs_type_t);
 extern int zfs_crypto_rename_check(zfs_handle_t *, struct zfs_cmd *);
 extern boolean_t zfs_valid_keysource(char *);
 extern boolean_t zfs_valid_set_keysource_change(zfs_handle_t *, char *, char *);

--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -1342,7 +1342,7 @@ zfs_valid_keysource(char *keysource)
  */
 int
 zfs_crypto_zckey(libzfs_handle_t *hdl, zfs_crypto_zckey_t cmd,
-    nvlist_t *props, zfs_cmd_t *zc)
+                 nvlist_t *props, zfs_cmd_t *zc, zfs_type_t type)
 {
 	uint64_t crypt = ZIO_CRYPT_INHERIT, pcrypt = ZIO_CRYPT_DEFAULT;
 	char *keysource = NULL;
@@ -1470,6 +1470,15 @@ zfs_crypto_zckey(libzfs_handle_t *hdl, zfs_crypto_zckey_t cmd,
 		ret = 0;
 		goto out;
 	}
+
+    /*
+     * If we are creating a volume, pick the valid cipher
+     */
+    /* If encryption is on, and volume, change it to valid cipher. */
+    if ((type == ZFS_TYPE_VOLUME) && (crypt != ZIO_CRYPT_OFF)) {
+        crypt = ZIO_CRYPT_AES_128_CTR;
+    }
+
 
 	/*
 	 * Need to pass down the inherited crypt value so that

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -1237,14 +1237,6 @@ badlabel:
             if (intval == ZIO_CRYPT_OFF)
                 break;
 
-            if (type == ZFS_TYPE_VOLUME) {
-                zfs_error_aux(hdl,
-                              dgettext(TEXT_DOMAIN, "encryption "
-                                       "is currently not supported on volumes"));
-                (void) zfs_error(hdl,
-                                 EZFS_PROPREADONLY, errbuf);
-                goto error;
-            }
             /*
              * Since encryption is on, we must make sure the user
              * did not specify a checksum so we can set it to
@@ -3228,7 +3220,7 @@ zfs_create(libzfs_handle_t *hdl, const char *path, zfs_type_t type,
 	}
 
     /* zfs_crypto_create may update props */
-    if (zfs_crypto_zckey(hdl, ZFS_CRYPTO_CREATE, props, &zc) != 0)
+    if (zfs_crypto_zckey(hdl, ZFS_CRYPTO_CREATE, props, &zc, type) != 0)
         return (-1);
 
 	if (props && zcmd_write_src_nvlist(hdl, &zc, props) != 0)
@@ -3493,7 +3485,7 @@ zfs_clone(zfs_handle_t *zhp, const char *target, nvlist_t *props)
 	(void) strlcpy(zc.zc_value, zhp->zfs_name, sizeof (zc.zc_value));
 
     /* may update props */
-    if (zfs_crypto_zckey(zhp->zfs_hdl, ZFS_CRYPTO_CLONE, props, &zc) != 0) {
+    if (zfs_crypto_zckey(zhp->zfs_hdl, ZFS_CRYPTO_CLONE, props, &zc, type) != 0) {
         nvlist_free(props);
         return (-1);
     }

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3002,9 +3002,6 @@ zfs_get_crypto_ctx(zfs_cmd_t *zc, dsl_crypto_ctx_t *dcc)
      * set via the zvol_preallocate_init() path.
      */
 
-    if (zc->zc_crypto.zic_crypt == ZIO_CRYPT_AES_128_CTR) {
-        return (ENOTSUP);
-    }
     switch (zc->zc_crypto.zic_cmd) {
     case ZFS_IOC_CRYPTO_KEY_LOAD:
         error = zcrypt_key_from_ioc(&zc->zc_crypto,
@@ -3606,8 +3603,15 @@ zfs_check_settable(const char *dsname, nvpair_t *pair, cred_t *cr)
         if (zfs_earlier_version(dsname, SPA_VERSION_CRYPTO))
             return (ENOTSUP);
 
-        if (zpl_earlier_version(dsname, ZPL_VERSION_SA))
-            return (ENOTSUP);
+        /*
+         * This property needs to be allowed when we are creating a volume.
+         * Find a solution for this.
+         */
+
+        /*
+          if (zpl_earlier_version(dsname, ZPL_VERSION_SA))
+          return (ENOTSUP);
+        */
 
         if (zfs_is_bootfs(dsname) && !BOOTFS_CRYPT_VALID(intval))
             return (ERANGE);


### PR DESCRIPTION
The way Solaris appears to set properties appears to be delayed, after
creation (maybe on volsize change?). Linux is now doing things differently,
the encryption property is set from libzfs, and passed along to ioctl.
This means libzfs now sets "aes-128-ctr" if ZVOL and crypt=on, and
ioctl allow for this cipher. (side effect, users could set CTR on normal
filesystems. Add test to stop this).

This now enabled crypt ZVOL. However, it will panic on import, so use
zpool import -N, and zfs key to load the key first.
