### PR TITLE
Fix import panic, and loading/unloading volumes

### DIFF
--- a/cmd/zfs/zfs_main.c
+++ b/cmd/zfs/zfs_main.c
@@ -6335,8 +6335,6 @@ zfs_key_callback(zfs_handle_t *zhp, int depth, void *data)
         return (0);
     }
 
-    fprintf(stderr, "zfs_key_callback\r\n");
-
     switch (cb->keycmd) {
     case KEY_LOAD:
         ret = zfs_key_load(zhp, B_TRUE, B_TRUE, cb->recurse);

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -1240,7 +1240,7 @@ zvol_free(zvol_state_t *zv)
 static int
 __zvol_create_minor(const char *name)
 {
-	zvol_state_t *zv;
+	zvol_state_t *zv = NULL;
 	objset_t *os;
 	dmu_object_info_t *doi;
 	uint64_t volsize;
@@ -1315,7 +1315,7 @@ __zvol_create_minor(const char *name)
 
 out_dmu_objset_disown:
 	dmu_objset_disown(os, zvol_tag);
-	zv->zv_objset = NULL;
+    if (zv) zv->zv_objset = NULL;
 out_doi:
 	kmem_free(doi, sizeof(dmu_object_info_t));
 out:


### PR DESCRIPTION
Make "zfs key -l" and "-u", which loads and unloads the key for ZVOL also
call zvol_create_minor() and zvol_remove_minor().

This completes the encrypted Volume support as well.

Removed debug print in zfs_main.
