### PR TITLE
Key inheritance fixes for ZVOL, root dataset encryption fixes. 

### DIFF
--- a/lib/libzfs/libzfs_crypto.c
+++ b/lib/libzfs/libzfs_crypto.c
@@ -1477,6 +1477,10 @@ zfs_crypto_zckey(libzfs_handle_t *hdl, zfs_crypto_zckey_t cmd,
     /* If encryption is on, and volume, change it to valid cipher. */
     if ((type == ZFS_TYPE_VOLUME) && (crypt != ZIO_CRYPT_OFF)) {
         crypt = ZIO_CRYPT_AES_128_CTR;
+        /* We also have to write out the prop, in the case of inheritance
+           or it will be using the wrong cipher */
+        VERIFY(nvlist_add_uint64(props,
+               zfs_prop_to_name(ZFS_PROP_ENCRYPTION), crypt) == 0);
     }
 
 


### PR DESCRIPTION
"zpool create -O encryption=on" would not set dataset properties correctly
nor load key.

ZVOL key inheritance (under an encrypted ZFS dataset) would pick wrong
cipher (use parent cipher instead of zvol's aes-128-ctr).

ZVOLs from key inheritance would not call zvol_create_minor() to populate
/dev/zd\* nodes.
