### PR TITLE
Document zfs_crypto_ignore_checksum_errors parameter

### DIFF
--- a/man/man5/zfs-module-parameters.5
+++ b/man/man5/zfs-module-parameters.5
@@ -876,6 +876,17 @@ Default value: \fB4\fR.
 .sp
 .ne 2
 .na
+\fBzfs_crypto_ignore_checksum_errors\fR (bool)
+.ad
+.RS 12n
+Disable crypto checksum checks.
+.sp
+Use \fB1\fR or \fBY\fR to disable and \fB0\fR or \fBN\fR for no (default).
+.RE
+
+.sp
+.ne 2
+.na
 \fBzfs_sync_pass_deferred_free\fR (int)
 .ad
 .RS 12n


### PR DESCRIPTION
An addition to a75f37a0f075eaf012648fd052fa1ea9f3562f5e which documents this parameter.

'Requires' pull request #42, which changed the param to a bool.
