### PR TITLE
Add missing userland crypto_mech2id();

### DIFF
--- a/lib/libspl/crypto.c
+++ b/lib/libspl/crypto.c
@@ -11,6 +11,11 @@
 
 
 
+int crypto_mech2id(char *name)
+{
+    return 0;
+}
+
 
 /*
  * HMAC-SHA-1 (from RFC 2202).


### PR DESCRIPTION
'zfs send' called dsl_hold_pool() more times than dsl_pool_rele().
'zfs recv' tried to hold rrwlock when already holding lock.
'zpool upgrade' from version=30 would panic, change to call dmu_objset_find() to iterate.
