### PR TITLE
zio_encrypt_data: crypto_encrypt 4 : corrupt file <0x0>

### DIFF
--- a/cmd/ztest/ztest.c
+++ b/cmd/ztest/ztest.c
@@ -5463,7 +5463,7 @@ ztest_ddt_repair(ztest_ds_t *zd, uint64_t id)
 	ztest_pattern_set(buf, psize, ~pattern);
 
 	(void) zio_wait(zio_rewrite(NULL, spa, 0, &blk,
-           buf, psize, NULL, NULL, ZIO_PRIORITY_SYNC_WRITE,
+           buf, psize, NULL, NULL, NULL, ZIO_PRIORITY_SYNC_WRITE,
 	    ZIO_FLAG_CANFAIL | ZIO_FLAG_INDUCE_DAMAGE, NULL));
 
 	zio_buf_free(buf, psize);

--- a/include/sys/zio.h
+++ b/include/sys/zio.h
@@ -499,7 +499,7 @@ extern zio_t *zio_write(zio_t *pio, spa_t *spa, uint64_t txg, blkptr_t *bp,
     zio_priority_t priority, enum zio_flag flags, const zbookmark_phys_t *zb);
 
 extern zio_t *zio_rewrite(zio_t *pio, spa_t *spa, uint64_t txg, blkptr_t *bp,
-    void *data, uint64_t size, zio_done_func_t *done, void *private,
+    void *data, uint64_t size, zio_prop_t *zp, zio_done_func_t *done, void *private,
     zio_priority_t priority, enum zio_flag flags, zbookmark_phys_t *zb);
 
 extern void zio_write_override(zio_t *zio, blkptr_t *bp, int copies,

--- a/module/zfs/ddt.c
+++ b/module/zfs/ddt.c
@@ -1040,7 +1040,7 @@ ddt_repair_entry(ddt_t *ddt, ddt_entry_t *dde, ddt_entry_t *rdde, zio_t *rio)
 		ddt_bp_create(ddt->ddt_checksum, ddk, ddp, &blk);
 		zio_nowait(zio_rewrite(zio, zio->io_spa, 0, &blk,
 		    rdde->dde_repair_data, DDK_GET_PSIZE(rddk),
-            NULL, NULL,
+		    NULL, NULL, NULL,
 		    ZIO_PRIORITY_SYNC_WRITE, ZIO_DDT_CHILD_FLAGS(zio), NULL));
 	}
 

--- a/module/zfs/zil.c
+++ b/module/zfs/zil.c
@@ -603,7 +603,7 @@ zil_create(zilog_t *zilog)
 		}
 		error = zio_alloc_zil(zilog->zl_spa, txg, &blk,
                               ZIL_MIN_BLKSZ, B_TRUE, zilog->zl_os->os_crypt);
-		fastwrite = TRUE; 
+		fastwrite = TRUE;
 
 		if (error == 0)
 			zil_init_log_chain(zilog, &blk);
@@ -1124,8 +1124,7 @@ zil_lwb_write_start(zilog_t *zilog, lwb_t *lwb)
 	 */
 	bzero(lwb->lwb_buf + lwb->lwb_nused, wsz - lwb->lwb_nused);
 
-	//zio_nowait(lwb->lwb_zio); /* Kick off the write for the old log block */
-	zio_wait(lwb->lwb_zio); /* Kick off the write for the old log block */
+	zio_nowait(lwb->lwb_zio); /* Kick off the write for the old log block */
 
 	/*
 	 * If there was an allocation failure then nlwb will be null which


### PR DESCRIPTION
During previous merge, the API change to zio_rewrite() missed the
zio_prop being passed and set. This meant zil_lwb_write_init() would
call zio_rewrite with a uninitialised zio 'crypto' value, causing the
above error. This meant the pool status was listed as corrupt, with bad
file:

status: One or more devices has experienced an error resulting in data
        corruption.  Applications may be affected.

errors: Permanent errors have been detected in the following files:
        BOOM/ccm:< 0x0 >

(which would be cleared on a Scrub).

In addition to this, recent kmem/vmem changes would cause
"Large kmem_alloc(34752, 0x0), please file an issue at:
   zil_set_crypto_data+0xac"

which has been fixed by calling vmem_alloc instead.
